### PR TITLE
Add catch-all alias support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vmail-lib"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "diesel 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel-derive-enum 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -579,7 +579,7 @@ dependencies = [
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-crypt 0.1.0 (git+https://github.com/awidegreen/password-hashing.git?branch=add_sha-crypt)",
- "vmail-lib 0.1.0",
+ "vmail-lib 0.1.1",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ vmail-cli alias show foo mydomain.org
 # Delete alias 'bar@mydomain.org'
 vmail-cli alias remove bar mydomain.org
 ```
+In order to add/remove a catch-all alias for a domain, the '%' (percentage)
+should be used as a username for the alias. Make sure that your database
+supports [such feature](https://thomas-leister.de/mailserver-debian-stretch/#wie-kann-ich-mit-diesem-setup-catch-all-adressen-realisieren).
+
+```
+# Add catch-all alias for 'mydomain.org' domain (alias for user 'foo')
+vmail-cli alias add % mydomain.org foo
+
+# Remove catch-all alias for 'mydomain.org' domain
+vmail-cli alias remove % mydomain.org
+```
 
 # Misc
 

--- a/src/cmd/alias.rs
+++ b/src/cmd/alias.rs
@@ -38,12 +38,24 @@ fn add(matches: &ArgMatches, conn: DatabaseConnection) -> Result<()> {
     let dest_name = matches.value_of("DEST_USER").unwrap();
     let dest_domain = matches.value_of("DEST_DOMAIN").unwrap_or_else(|| domain);
 
-    if Account::get(&conn, name, domain).is_ok() {
+    if Account::exsits(&conn, name, domain) {
         return Err(format_err!(
             "Unable to add alias: '{}@{}' exists as a user-account!",
             name,
             domain
         ));
+    }
+
+    if !Account::exsits(&conn, dest_name, dest_domain) {
+        if !Alias::exsits(&conn, dest_name, dest_domain) {
+            return Err(format_err!(
+                "Unable to add alias '{}@{}' as destination '{}@{}' does not exists as user account nor as an existing alias!",
+                name,
+                domain,
+                dest_name,
+                dest_domain,
+            ));
+        }
     }
 
     let a = Alias::with_address(name, domain)
@@ -125,58 +137,73 @@ pub fn get_subcommand() -> App<'static, 'static> {
                     Arg::with_name("DEST_USER")
                         .requires("DEST_DOMAIN")
                         .help("username to filter for"),
-                ).arg(Arg::with_name("DEST_DOMAIN").help("domain to filter for")),
-        ).subcommand(
+                )
+                .arg(Arg::with_name("DEST_DOMAIN").help("domain to filter for")),
+        )
+        .subcommand(
             SubCommand::with_name("add")
-                .about("Add an alias to an existing user account")
+                .about(
+                    "Add an alias to an existing user account. See USER help for catch-all aliases",
+                )
                 .aliases(&["create", "new"])
                 .arg(
                     Arg::with_name("USER")
-                        .required(true)
-                        .help("The username for the alias"),
-                ).arg(
+                    .required(true)
+                    .long_help(
+"Username for the alias. If the username is specified as '%'
+(percentage) it will act as a catch-all user.",))
+                .arg(
                     Arg::with_name("DOMAIN")
                         .required(true)
                         .help("Existing domain for the alias"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("DEST_USER")
                         .required(true)
                         .help("Existing user account"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("DEST_DOMAIN")
-                        .help("If not specified, this will assume to DOMAIN value"),
-                ).arg(
+                        .help("If not specified, this will assume the <DOMAIN> value"),
+                )
+                .arg(
                     Arg::with_name("disabled")
                         .long("disabled")
                         .short("d")
                         .help("Set alias to disabled"),
                 ),
-        ).subcommand(
+        )
+        .subcommand(
             SubCommand::with_name("remove")
-                .about("Remove aliases from the database")
+                .about("Remove aliases from the database. See <USER> argument help for remove a catch-all user.")
                 .alias("rm")
                 .alias("delete")
                 .arg(
                     Arg::with_name("USER")
                         .required(true)
-                        .help("Username for the alias"),
-                ).arg(
+                        .long_help(
+"Username for the alias. For removing a catch-all alias, the '%'
+(percentage) should be used as a <USER>."))
+                .arg(
                     Arg::with_name("DOMAIN")
                         .required(true)
                         .help("Domain of the alias (need to exist)"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("dest_user")
                         .value_name("dest_user")
                         .long("destination-user")
                         .short("u")
                         .help("Filter on destination account/user name"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("dest_domain")
                         .value_name("dest_domain")
                         .long("destination-domain")
                         .short("d")
                         .help("Filter on destination account/user domain"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("force")
                         .long("force")
                         .short("f")

--- a/src/cmd/domain.rs
+++ b/src/cmd/domain.rs
@@ -132,14 +132,16 @@ pub fn get_subcommand() -> App<'static, 'static> {
                         .long("with-users")
                         .short("u")
                         .help("Show all users for the domain"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("with-aliases")
                         .long("with-aliases")
                         .short("a")
                         .requires("with-users")
                         .help("Show all aliases for the users"),
                 ),
-        ).subcommand(
+        )
+        .subcommand(
             SubCommand::with_name("add")
                 .about("Add a new domain to the database")
                 .arg(
@@ -147,22 +149,26 @@ pub fn get_subcommand() -> App<'static, 'static> {
                         .required(true)
                         .help("The domain name which should be added."),
                 ),
-        ).subcommand(
+        )
+        .subcommand(
             SubCommand::with_name("remove")
                 .about(
                     "Remove a domain from the database, this will also delete all related users.",
-                ).aliases(&["rm", "delete"])
+                )
+                .aliases(&["rm", "delete"])
                 .arg(
                     Arg::with_name("force")
                         .long("force")
                         .short("f")
                         .help("Force the deleting the given domain"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("verbose")
                         .long("verbose")
                         .short("v")
                         .help("Verbose output what has been deleted"),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("DOMAIN")
                         .required(true)
                         .help("The domain name which should be deleted."),

--- a/src/cmd/user.rs
+++ b/src/cmd/user.rs
@@ -52,7 +52,7 @@ fn show(matches: &ArgMatches, conn: DatabaseConnection, domain: Option<&str>) ->
             if let Ok(aliases) = Alias::all_by_dest_account(&conn, acc) {
                 println!("Aliases: ");
                 for al in aliases {
-                    println!(" {}@{} ", al.source_username, al.source_domain);
+                    println!(" {}@{} ", al.source_username(), al.source_domain);
                 }
             }
         }

--- a/vmail-lib/Cargo.toml
+++ b/vmail-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmail-lib"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Armin Widegreen <vmail@widegreen.net>"]
 
 [dependencies]

--- a/vmail-lib/migrations/2019-02-28-210537_allow_catchall/down.sql
+++ b/vmail-lib/migrations/2019-02-28-210537_allow_catchall/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE aliases 
+MODIFY source_username VARCHAR(64) NOT NULL;

--- a/vmail-lib/migrations/2019-02-28-210537_allow_catchall/up.sql
+++ b/vmail-lib/migrations/2019-02-28-210537_allow_catchall/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE aliases 
+MODIFY source_username VARCHAR(64) NULL;

--- a/vmail-lib/src/schema.rs
+++ b/vmail-lib/src/schema.rs
@@ -16,7 +16,7 @@ table! {
 table! {
     aliases (id) {
         id -> Integer,
-        source_username -> Varchar,
+        source_username -> Nullable<Varchar>,
         source_domain -> Varchar,
         destination_username -> Varchar,
         destination_domain -> Varchar,


### PR DESCRIPTION
Catch-all aliases can now be added/removed for a domain. Therefore the '%'
should be used as a username for the alias add | remove subcommands.

#4 