### PR TITLE
Make it easier to switch to another database backend

### DIFF
--- a/vmail-lib/src/account.rs
+++ b/vmail-lib/src/account.rs
@@ -1,12 +1,12 @@
 #![allow(proc_macro_derive_resolution_fallback)]
 use diesel;
-use diesel::mysql::MysqlConnection;
 use diesel::prelude::*;
 use domain::Domain;
 use schema::accounts;
 use std::fmt;
 
 use result::{Result, VmailError};
+use database::DatabaseConnection;
 
 #[derive(Identifiable, AsChangeset, Queryable, PartialEq, Debug)]
 pub struct Account {
@@ -56,7 +56,7 @@ impl fmt::Display for Account {
 }
 
 impl Account {
-    pub fn get(conn: &MysqlConnection, name: &str, domain_: &str) -> Result<Account> {
+    pub fn get(conn: &DatabaseConnection, name: &str, domain_: &str) -> Result<Account> {
         use schema::accounts::dsl::*;
 
         let mut r = accounts
@@ -75,7 +75,7 @@ impl Account {
         )));
     }
 
-    pub fn all_by_username(conn: &MysqlConnection, name: &str) -> Result<Vec<Account>> {
+    pub fn all_by_username(conn: &DatabaseConnection, name: &str) -> Result<Vec<Account>> {
         use schema::accounts::dsl::*;
 
         let r = accounts
@@ -90,7 +90,7 @@ impl Account {
         bail!(VmailError::NotFound(format!("Account username: {}", name)));
     }
 
-    pub fn all_by_domain(conn: &MysqlConnection, d: &Domain) -> Result<Vec<Account>> {
+    pub fn all_by_domain(conn: &DatabaseConnection, d: &Domain) -> Result<Vec<Account>> {
         use schema::accounts::dsl::*;
 
         let r = accounts
@@ -107,14 +107,14 @@ impl Account {
         )));
     }
 
-    pub fn all(conn: &MysqlConnection) -> Result<Vec<Account>> {
+    pub fn all(conn: &DatabaseConnection) -> Result<Vec<Account>> {
         use schema::accounts::dsl::*;
         let r = accounts.load::<Account>(conn)?;
         Ok(r)
     }
 
     /// returns number of rows inserted
-    pub fn create(conn: &MysqlConnection, account: NewAccount) -> Result<usize> {
+    pub fn create(conn: &DatabaseConnection, account: NewAccount) -> Result<usize> {
         use schema::accounts;
 
         let n = diesel::insert_into(accounts::table)
@@ -124,14 +124,14 @@ impl Account {
     }
 
     /// returns number of rows deleted
-    pub fn delete(conn: &MysqlConnection, account: &Account) -> Result<usize> {
+    pub fn delete(conn: &DatabaseConnection, account: &Account) -> Result<usize> {
         use schema::accounts::dsl::*;
 
         let n = diesel::delete(accounts.find(account.id)).execute(conn)?;
         Ok(n)
     }
 
-    pub fn exsits(conn: &MysqlConnection, name: &str, domain_name: &str) -> bool {
+    pub fn exsits(conn: &DatabaseConnection, name: &str, domain_name: &str) -> bool {
         use diesel::dsl::exists;
         use diesel::select;
         use schema::accounts::dsl::*;
@@ -148,7 +148,7 @@ impl Account {
         }
     }
 
-    pub fn save(conn: &MysqlConnection, account: &Account) -> Result<usize> {
+    pub fn save(conn: &DatabaseConnection, account: &Account) -> Result<usize> {
         let n = diesel::update(account).set(account).execute(conn)?;
         Ok(n)
     }

--- a/vmail-lib/src/alias.rs
+++ b/vmail-lib/src/alias.rs
@@ -1,11 +1,11 @@
 #![allow(proc_macro_derive_resolution_fallback)]
 
 use account::Account;
-use diesel::mysql::MysqlConnection;
 use diesel::prelude::*;
 use schema::aliases;
 use std::fmt;
 
+use database::DatabaseConnection;
 use result::{Result, VmailError};
 
 #[derive(Queryable, PartialEq, Debug)]
@@ -108,7 +108,7 @@ impl Alias {
         }
     }
 
-    pub fn get(conn: &MysqlConnection, name: &str, domain: &str) -> Result<Vec<Alias>> {
+    pub fn get(conn: &DatabaseConnection, name: &str, domain: &str) -> Result<Vec<Alias>> {
         use schema::aliases::dsl::*;
 
         let r = if name == "%" {
@@ -125,14 +125,14 @@ impl Alias {
         Ok(r)
     }
 
-    pub fn all(conn: &MysqlConnection) -> Result<Vec<Alias>> {
+    pub fn all(conn: &DatabaseConnection) -> Result<Vec<Alias>> {
         use schema::aliases::dsl::*;
 
         let r = aliases.load::<Alias>(conn)?;
         Ok(r)
     }
 
-    pub fn all_by_dest_account(conn: &MysqlConnection, account: &Account) -> Result<Vec<Alias>> {
+    pub fn all_by_dest_account(conn: &DatabaseConnection, account: &Account) -> Result<Vec<Alias>> {
         use schema::aliases::dsl::*;
 
         let r = aliases
@@ -150,7 +150,7 @@ impl Alias {
         )));
     }
 
-    pub fn delete(conn: &MysqlConnection, alias: &Alias) -> Result<usize> {
+    pub fn delete(conn: &DatabaseConnection, alias: &Alias) -> Result<usize> {
         use diesel::delete;
         use schema::aliases::dsl::*;
 
@@ -158,7 +158,7 @@ impl Alias {
         Ok(n)
     }
 
-    pub fn create(conn: &MysqlConnection, alias: &NewAlias) -> Result<usize> {
+    pub fn create(conn: &DatabaseConnection, alias: &NewAlias) -> Result<usize> {
         use diesel;
         use diesel::insert_into;
         use schema::aliases;
@@ -179,7 +179,7 @@ impl Alias {
         }
     }
 
-    pub fn exsits(conn: &MysqlConnection, name: &str, domain_name: &str) -> bool {
+    pub fn exsits(conn: &DatabaseConnection, name: &str, domain_name: &str) -> bool {
         use diesel::dsl::exists;
         use diesel::select;
         use schema::aliases::dsl::*;

--- a/vmail-lib/src/database.rs
+++ b/vmail-lib/src/database.rs
@@ -1,0 +1,10 @@
+use diesel::connection::Connection;
+use diesel::mysql::MysqlConnection;
+
+pub type DatabaseConnection = MysqlConnection;
+
+pub fn connect(database_url: &str) -> DatabaseConnection {
+
+    DatabaseConnection::establish(&database_url)
+        .expect(&format!("Error connecting to {}", database_url))
+}

--- a/vmail-lib/src/domain.rs
+++ b/vmail-lib/src/domain.rs
@@ -1,10 +1,10 @@
 #![allow(proc_macro_derive_resolution_fallback)]
-use diesel::mysql::MysqlConnection;
 use diesel::prelude::*;
 use schema::domains;
 use std::fmt;
 
 use result::{Result, VmailError};
+use database::DatabaseConnection;
 
 #[derive(Queryable, PartialEq, Debug)]
 pub struct Domain {
@@ -25,14 +25,14 @@ impl fmt::Display for Domain {
 }
 
 impl Domain {
-    pub fn all(conn: &MysqlConnection) -> Result<Vec<Domain>> {
+    pub fn all(conn: &DatabaseConnection) -> Result<Vec<Domain>> {
         use schema::domains::dsl::*;
 
         let r = domains.load::<Domain>(conn)?;
         Ok(r)
     }
 
-    pub fn get(conn: &MysqlConnection, name: &str) -> Result<Domain> {
+    pub fn get(conn: &DatabaseConnection, name: &str) -> Result<Domain> {
         use schema::domains::dsl::*;
 
         let mut r = domains
@@ -47,7 +47,7 @@ impl Domain {
         bail!(VmailError::NotFound(format!("Domain {}", name)));
     }
 
-    pub fn exsits(conn: &MysqlConnection, name: &str) -> Result<bool> {
+    pub fn exsits(conn: &DatabaseConnection, name: &str) -> Result<bool> {
         use diesel::dsl::exists;
         use diesel::select;
         use schema::domains::dsl::*;
@@ -57,7 +57,7 @@ impl Domain {
     }
 
     /// returns number of rows inserted
-    pub fn create(conn: &MysqlConnection, domain: NewDomain) -> Result<usize> {
+    pub fn create(conn: &DatabaseConnection, domain: NewDomain) -> Result<usize> {
         use diesel::insert_into;
         use schema::domains;
 
@@ -66,7 +66,7 @@ impl Domain {
     }
 
     /// returns number of rows deleted
-    pub fn delete(conn: &MysqlConnection, d: &Domain) -> Result<usize> {
+    pub fn delete(conn: &DatabaseConnection, d: &Domain) -> Result<usize> {
         use diesel::delete;
         use schema::domains::dsl::*;
 

--- a/vmail-lib/src/lib.rs
+++ b/vmail-lib/src/lib.rs
@@ -8,12 +8,13 @@ extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 
-use diesel::connection::Connection;
-use diesel::mysql::MysqlConnection;
 use dotenv::dotenv;
 use std::env;
+use database::connect;
+pub use database::DatabaseConnection;
 
 pub mod result;
+mod database;
 
 pub mod account;
 pub mod alias;
@@ -21,13 +22,10 @@ pub mod domain;
 pub mod schema;
 pub mod tlspolicy;
 
-pub type DatabaseConnection = MysqlConnection;
-
 pub fn establish_connection() -> DatabaseConnection {
     dotenv().ok();
 
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
 
-    DatabaseConnection::establish(&database_url)
-        .expect(&format!("Error connecting to {}", database_url))
+    connect(&database_url)
 }


### PR DESCRIPTION
Hi! I personally use a mail server setup created from Thomas Leistner's tutorial and am very happy with it. I use a postgres database instead of a mysql one.

To make it possible to use this management tool, I made some changes that help to switch to another database backend like postgres. Now, the database backend is specified in a single line and can be switched more easily.

I'm pretty new to rust, so I hope my changes are fine. This PR should not change the behaviour of `vmail-lib`.